### PR TITLE
Update build-container.sh and run-container.sh to fix errors which occur if path contains spaces

### DIFF
--- a/build-container.sh
+++ b/build-container.sh
@@ -13,4 +13,4 @@ fi
 
 WORKDIR=$(cd -- "$(dirname -- "$0")" && pwd)
 
-$CM build -t dsm-kmip-server:latest $WORKDIR
+$CM build -t dsm-kmip-server:latest "$WORKDIR"

--- a/run-container.sh
+++ b/run-container.sh
@@ -22,6 +22,6 @@ fi
 echo "=== Starting new container"
 $CM run -d --name dsm-kmip-server -p 5696:5696 \
     --restart=unless-stopped \
-    --mount type=bind,source=$WORKDIR/state,target=/var/lib/state \
-    --mount type=bind,source=$WORKDIR/certs,target=/var/lib/certs \
+    --mount type=bind,source="$WORKDIR"/state,target=/var/lib/state \
+    --mount type=bind,source="$WORKDIR"/certs,target=/var/lib/certs \
     dsm-kmip-server:latest


### PR DESCRIPTION
Fixed an issue where user would get an error if the WORKDIR contained spaces.