### PR TITLE
Use specific PyKMIP version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM alpine:3.19
 
 RUN apk add --no-cache py3-pip openssl
 
+COPY requirements.txt .
+
 RUN apk add --no-cache --virtual build-deps \
-    python3-dev openssl-dev libffi-dev musl-dev gcc rust cargo && \
-    pip install pykmip --break-system-packages && \
+    python3-dev openssl-dev libffi-dev musl-dev gcc rust cargo git && \
+    pip install -r requirements.txt --break-system-packages && \
     apk del build-deps
 
 RUN mkdir -p /etc/pykmip \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/OpenKMIP/PyKMIP@6cd44b572b0ca55adf01a8a12078b2284602e64c


### PR DESCRIPTION
Installing from requirements.txt also makes it possible to use Dependabot in the future. Should help people from #13