### PR TITLE
Feature/logging stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,9 @@ $ sudo journalctl -u kmip.service -ef
 ```
 
 On KMIP server side:
-1. Jump into the container (replace podman with docker if needed):
+1. check logs of the container (replace podman with docker if needed):
 ```
-$ podman exec -ti dsm-kmip-server /bin/sh
-```
-2. Check pykmip logs:
-```
-$ cat /var/log/pykmip/server.log
+$ podman logs -f dsm-kmip-server
 ```
 
 ## Tips on creating encrypted storage on Raspberry Pi

--- a/assets/init.sh
+++ b/assets/init.sh
@@ -57,4 +57,5 @@ if [ ! -f /var/lib/certs/client.crt ]; then
         -days $CLIENT_CERT_LIFETIME -CAcreateserial -copy_extensions copy
 fi
 
-pykmip-server
+# Ensure pykmip-server logs are directed to stdout
+pykmip-server -l /dev/stdout


### PR DESCRIPTION
Hi Renat,

first of all, thanks for your efforts with PyKMIP! I found your Repo on Reddit while facing the same dilemma with my DSM machine. Once again, the effort is appreciated. 👍 

This pull request changes the default log destination from /var/log/pykmip/server.log to "Standard Out" to simplify the administration.
It's best practice for containers to treat logs like event streams for further aggregation/collection etc.

Best regards
Marcel